### PR TITLE
Run the embedded XServer as a foreground service

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
         tools:ignore="ScopedStorage" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
 
     <application
         android:name=".Tc4Application"
@@ -63,6 +64,16 @@
         <activity
             android:name=".ui.page.LicenseActivity"
             android:exported="false" />
+
+        <service
+            android:name=".x11.XServerService"
+            android:exported="false"
+            android:foregroundServiceType="specialUse"
+            android:process=":xserver">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="@string/tc4_xserver_special_use" />
+        </service>
 
         <provider
             android:name=".ui.misc.TinyDocumentsProvider"

--- a/app/src/main/java/com/fct/tc4/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/fct/tc4/ui/main/MainActivity.kt
@@ -45,8 +45,8 @@ import com.fct.tc4.ui.page.ContainerManageFragment
 import com.fct.tc4.ui.misc.Global
 import com.fct.tc4.ui.page.TerminalFragment
 import com.fct.tc4.ui.page.ContainerManageViewModel
+import com.fct.tc4.x11.XServerService
 import com.google.android.material.snackbar.Snackbar
-import com.termux.x11.CmdEntryPointService
 import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -382,9 +382,7 @@ class MainActivity : AppCompatActivity() {
     override fun onDestroy() {
         super.onDestroy()
         if (!isChangingConfigurations) {
-            startService(Intent(
-                this, CmdEntryPointService::class.java
-            ).apply { action = CmdEntryPointService.ACTION_STOP })
+            XServerService.stop(this)
         }
     }
 

--- a/app/src/main/java/com/fct/tc4/ui/page/ContainerMainViewModel.kt
+++ b/app/src/main/java/com/fct/tc4/ui/page/ContainerMainViewModel.kt
@@ -22,7 +22,6 @@ import android.content.Intent
 import android.system.Os
 import android.system.OsConstants
 import android.util.Log
-import com.termux.x11.CmdEntryPointService
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -36,6 +35,7 @@ import com.fct.tc4.ui.misc.ConfigManager
 import com.fct.tc4.ui.misc.Global
 import com.fct.tc4.ui.misc.UpdateChecker
 import com.fct.tc4.ui.misc.UpdateResult
+import com.fct.tc4.x11.XServerService
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -321,19 +321,12 @@ class ContainerMainViewModel(
             "1",
             app.packageName
         )
-        app.startService(Intent(app, CmdEntryPointService::class.java).apply {
-            action = CmdEntryPointService.ACTION_START
-            putExtra(CmdEntryPointService.EXTRA_ARGS, xserverArgs.toTypedArray())
-            putExtra(CmdEntryPointService.EXTRA_ENV_KEYS, envKeys)
-            putExtra(CmdEntryPointService.EXTRA_ENV_VALUES, envVals)
-        })
+        XServerService.start(app, xserverArgs.toTypedArray(), envKeys, envVals)
     }
 
     private fun killXServer() {
         if (xserverStarted) {
-            getApplication<Application>().startService(Intent(
-                getApplication(), CmdEntryPointService::class.java
-            ).apply { action = CmdEntryPointService.ACTION_STOP })
+            XServerService.stop(getApplication())
             xserverStarted = false
         }
     }

--- a/app/src/main/java/com/fct/tc4/x11/XServerService.kt
+++ b/app/src/main/java/com/fct/tc4/x11/XServerService.kt
@@ -1,0 +1,109 @@
+// XServerService.kt -- This file is part of tiny_container.
+//
+// Copyright (C) 2026 Caten Hu
+//
+// Tiny Container is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published
+// by the Free Software Foundation, either version 3 of the License,
+// or any later version.
+
+package com.fct.tc4.x11
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.ServiceCompat
+import com.fct.tc4.R
+import com.fct.tc4.ui.main.MainActivity
+import com.termux.x11.CmdEntryPointService
+
+/** Runs the embedded Termux:X11 server as a foreground service in the :xserver process. */
+class XServerService : CmdEntryPointService() {
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (intent?.action == ACTION_START) {
+            promoteToForeground()
+        }
+
+        return super.onStartCommand(intent, flags, startId)
+    }
+
+    private fun promoteToForeground() {
+        createNotificationChannel()
+
+        val openAppIntent = Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
+        }
+        val contentIntent = PendingIntent.getActivity(
+            this,
+            0,
+            openAppIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        val notification = NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
+            .setSmallIcon(R.drawable.screen_share_24dp_1f1f1f_fill0_wght400_grad0_opsz24)
+            .setContentTitle(getString(R.string.tc4_app_name))
+            .setContentText(getString(R.string.tc4_xserver_notification_text))
+            .setContentIntent(contentIntent)
+            .setCategory(NotificationCompat.CATEGORY_SERVICE)
+            .setOngoing(true)
+            .setSilent(true)
+            .setOnlyAlertOnce(true)
+            .build()
+
+        val foregroundServiceType =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
+            } else {
+                0
+            }
+        ServiceCompat.startForeground(
+            this,
+            NOTIFICATION_ID,
+            notification,
+            foregroundServiceType
+        )
+    }
+
+    private fun createNotificationChannel() {
+        val channel = NotificationChannel(
+            NOTIFICATION_CHANNEL_ID,
+            getString(R.string.tc4_app_name),
+            NotificationManager.IMPORTANCE_LOW
+        ).apply {
+            setShowBadge(false)
+        }
+        getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
+    }
+
+    companion object {
+        private const val NOTIFICATION_CHANNEL_ID = "xserver"
+        private const val NOTIFICATION_ID = 1001
+
+        fun start(
+            context: Context,
+            args: Array<String>,
+            envKeys: Array<String>,
+            envValues: Array<String>
+        ) {
+            val intent = Intent(context, XServerService::class.java).apply {
+                action = ACTION_START
+                putExtra(EXTRA_ARGS, args)
+                putExtra(EXTRA_ENV_KEYS, envKeys)
+                putExtra(EXTRA_ENV_VALUES, envValues)
+            }
+            context.startForegroundService(intent)
+        }
+
+        fun stop(context: Context) {
+            context.startService(Intent(context, XServerService::class.java).apply {
+                action = ACTION_STOP
+            })
+        }
+    }
+}

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <string name="tc4_app_name">小小容器</string>
+    <string name="tc4_xserver_notification_text">小小容器正在提供 X11 显示服务</string>
 
     <!-- ==================== Common Buttons ==================== -->
     <string name="tc4_btn_ok">确定</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,7 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="tc4_app_name">Tiny Container</string>
+    <string name="tc4_xserver_notification_text" tools:ignore="MissingTranslation">Tiny Container is providing the X11 display server</string>
+    <string name="tc4_xserver_special_use" translatable="false">Keeps the local X11 display server available while the user is running a Linux desktop</string>
 
     <!-- ==================== Common Buttons ==================== -->
     <string name="tc4_btn_ok">OK</string>


### PR DESCRIPTION
## Background

Tiny Container provides two ways to access the graphical desktop: AVNC and X11 (`Termux:X11`). On a Xiaomi Pad 6S Pro running HyperOS 3 with 8 GB of RAM, X11 would frequently disconnect and display “not connected”. This issue did not occur when using AVNC.

Investigation showed that the container itself continued running, but the `com.fct.tc4:xserver` process had an `oom_score_adj` value of `800`. Android could terminate it under increased background memory pressure, leaving X11 unable to reconnect to the graphical desktop.

## Changes

- Add `XServerService` based on the existing `CmdEntryPointService`.
- Run the XServer as an Android foreground service with a low-importance ongoing notification.
- Declare the `specialUse` foreground-service type for recent Android versions.
- Route the existing XServer start and stop operations through the new service.
- Preserve the existing launch arguments, environment variables, and shutdown behavior.

## Results

The XServer's `oom_score_adj` was reduced from `800` to `200`, and Android now recognizes it as a foreground-service process.

During testing with multiple background applications and elevated memory pressure, neither XServer termination nor X11 disconnection was reproduced. Stopping and restarting the container also restarted the XServer and graphical desktop normally.

---

## 背景

Tiny Container 提供 AVNC 和 X11（`Termux:X11`）两种图形桌面连接方式。在搭载澎湃 OS 3、8 GB 内存的小米平板 6S Pro 上，使用 X11 时会在运行过程中频繁断联并显示“未连接”，而使用 AVNC 时没有出现该断联问题。

排查发现，容器本身仍在正常运行，但 `com.fct.tc4:xserver` 进程的 `oom_score_adj` 为 `800`，在后台内存压力增大时容易被 Android 系统终止，导致 X11 无法重新连接图形桌面。

## 修改

- 增加基于现有 `CmdEntryPointService` 的 `XServerService`。
- 将 XServer 作为 Android 前台服务运行，并显示低优先级常驻通知。
- 为较新 Android 版本声明 `specialUse` 前台服务类型。
- 将原有 XServer 启动和停止入口切换到新服务。
- 保留原有的启动参数、环境变量和停止行为。

## 效果

修改前，XServer 的 `oom_score_adj` 为 `800`；修改后降至 `200`，Android 将其识别为前台服务进程。

在开启多个后台应用并制造较高内存压力后，测试期间未再复现 XServer 被系统终止或 X11 断联的问题。停止并重新启动容器后，XServer 和图形桌面也能正常重新启动。
